### PR TITLE
add initial MITgcm method; use it in pkg test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: julia
 os:
   - linux
-  - osx
 julia:
   - 1.1
   - 1.3
@@ -13,6 +12,7 @@ notifications:
 before_install:
   - sudo apt-get -y install gcc
   - sudo apt-get -y install gfortran
+  - sudo apt-get -y install openmpi-bin
 
 after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ notifications:
 
 before_install:
   - sudo apt-get -y install gcc
-  - sudo apt-get -y install gcc-gfortran
+  - sudo apt-get -y install gfortran
   - sudo apt-get -y install openmpi-devel
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ notifications:
 before_install:
   - sudo apt-get -y install gcc
   - sudo apt-get -y install gfortran
-  - sudo apt-get -y install openmpi-devel
 
 after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ julia:
 notifications:
   email: false
 
+before_install:
+  - sudo apt-get -y install gcc
+  - sudo apt-get -y install gcc-gfortran
+  - sudo apt-get -y install openmpi-devel
+
 after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ os:
   - osx
 julia:
   - 1.1
-  - 1.2
   - 1.3
   - nightly
 notifications:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimateTasks"
 uuid = "1a49d507-8691-47fa-b95e-812ffcc74e70"
 authors = ["gaelforget <gforget@mit.edu>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@
 [![Coveralls](https://coveralls.io/repos/github/gaelforget/ClimateTasks.jl/badge.svg?branch=master)](https://coveralls.io/github/gaelforget/ClimateTasks.jl?branch=master)
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3633454.svg)](https://doi.org/10.5281/zenodo.3633454)
+
+Set of tools that assemble, launch, distribute, and/or schedule common computational tasks related to climate research.
+
+_This package is in early developement stage when breaking changes are to be expected._

--- a/examples/task.yml
+++ b/examples/task.yml
@@ -1,0 +1,15 @@
+Date           : 2019-04-20
+Author         : Gael Forget
+InputDir       :
+  - diags/
+InputFile      : 
+  - state_2d_set1
+InputSize      :
+  - [720, 360] 
+Specs          : 
+  name         : task1
+  file         : MTRX.jld
+  mask         : msk2d
+OutputDir      : diags_interp/
+OutputSize     : [720, 360]
+

--- a/src/ClimateTasks.jl
+++ b/src/ClimateTasks.jl
@@ -7,5 +7,6 @@ using JLD, YAML
 include("Main.jl")
 
 export StartWorkers, TaskDriver, task1_loop
+export MITgcm
 
 end # module

--- a/src/Main.jl
+++ b/src/Main.jl
@@ -6,9 +6,10 @@ Run MITgcm; download it if needed.
 """
 function MITgcm(p::String="./",c::Cmd=`./testreport -t hs94.cs-32x32x5`)
    d=pwd()
+   cd(p)
    test=~isdir("MITgcm")
-   isempty(p)&&test ? run(`git clone https://github.com/MITgcm/MITgcm`) : nothing
-   cd("$p"*"MITgcm/verification/")
+   test ? run(`git clone https://github.com/MITgcm/MITgcm`) : nothing
+   cd("MITgcm/verification/")
    run(c)
    cd(d)
 end

--- a/src/Main.jl
+++ b/src/Main.jl
@@ -1,5 +1,19 @@
 
 """
+    MITgcm(p::String)
+
+Run MITgcm; download it if needed.
+"""
+function MITgcm(p::String="./",c::Cmd=`./testreport -t hs94.cs-32x32x5`)
+   d=pwd()
+   test=~isdir("MITgcm")
+   isempty(p)&&test ? run(`git clone https://github.com/MITgcm/MITgcm`) : nothing
+   cd("$p"*"MITgcm/verification/")
+   run(c)
+   cd(d)
+end
+
+"""
     StartWorkers(nwrkrs::Int)
 
 Start workers if needed.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,5 +2,5 @@ using ClimateTasks
 using Test
 
 @testset "ClimateTasks.jl" begin
-    # Write your own tests here.
+    MITgcm()
 end


### PR DESCRIPTION
This involved adding `gcc` + `gfortran` (+ `openmpi`) in `.travis.yaml`. For now `runtests.jl` simply runs `MITgcm` -- still need to scan output and check against reference result to make this into proper unit tests.